### PR TITLE
Promethus Metrics

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(
         'http_sfv>=0.9.8',
         'dataclasses_json>=0.5.7',
         'apispec>=6.3.0',
+        'prometheus-client>=0.17.1'
     ],
     extras_require={
         # eg:

--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -71,15 +71,15 @@ def setup(name, bran, adminPort, bootPort, base='', httpPort=None, configFile=No
     if os.getenv("KERI_AGENT_CORS", "false").lower() in ("true", "1"):
         app.add_middleware(middleware=httping.HandleCORS())
     allowed_routes = ["/agent"]
-     # if os.getenv("KERI_AGENT_METRICS", "false").lower() in ("true", "1"):
-    promethus = MetricsMiddleware()
-    bootApp.add_middleware(promethus)
-    MetricsEnds = MetricsEndpoint(promethus.registry)
-    bootApp.add_route("/metrics", MetricsEnds)
+    if os.getenv("KERI_AGENT_METRICS", "false").lower() in ("true", "1"):
+        promethus = MetricsMiddleware()
+        bootApp.add_middleware(promethus)
+        MetricsEnds = MetricsEndpoint(promethus.registry)
+        bootApp.add_route("/metrics", MetricsEnds)
 
-    app.add_middleware(promethus)
-    app.add_route("/metrics", promethus)
-    allowed_routes.append("/metrics")
+        app.add_middleware(promethus)
+        app.add_route("/metrics", promethus)
+        allowed_routes.append("/metrics")
 
     app.add_middleware(authing.SignatureValidationComponent(agency=agency, authn=authn, allowed=allowed_routes))
     app.req_options.media_handlers.update(media.Handlers())

--- a/src/keria/app/metrics.py
+++ b/src/keria/app/metrics.py
@@ -1,0 +1,41 @@
+from prometheus_client import CollectorRegistry, Counter, Histogram, generate_latest
+import time
+
+# Define metrics
+REQUESTS = Counter('requests_total', 'Total Request Count', ['method', 'path', 'resource'])
+ERRORS = Counter('errors_total', 'Total Error Count', ['method', 'path', 'resource', 'status'])
+DURATION = Histogram('request_duration_seconds', 'Duration of requests', ['method', 'path', 'resource'])
+
+class MetricsMiddleware:
+    def __init__(self):
+        """Initialize the middleware with Prometheus metrics."""
+        self.registry = CollectorRegistry()
+        self.registry.register(REQUESTS)
+        self.registry.register(ERRORS)
+        self.registry.register(DURATION)
+    def process_request(self, req, resp):
+        """Process the request before routing it."""
+        req.context['resource'] = req.get_header('signify-resource')
+        req.context['start_time'] = time.time()
+
+    def process_resource(self, req, resp, resource, params):
+        """Process the request after routing."""
+        REQUESTS.labels(method=req.method, path=req.path, resource=req.context['resource']).inc()
+
+    def process_response(self, req, resp, resource, req_succeeded):
+        """Post-processing of the response (after routing)."""
+        if 'start_time' in req.context:
+            duration = time.time() - req.context['start_time']
+            DURATION.labels(method=req.method, path=req.path, resource=req.context.get('resource', '')).observe(duration)
+
+        if not req_succeeded:
+            ERRORS.labels(method=req.method, path=req.path, resource=req.context.get('resource', ''), status=resp.status).inc()
+
+class MetricsEndpoint:
+    def __init__(self, registry):
+        self.registry = registry
+    
+    def on_get(self, req, resp):
+        resp.content_type = 'text/plain; version=0.0.4; charset=utf-8'
+        data = generate_latest(self.registry)
+        resp.body = str(data.decode('utf-8'))


### PR DESCRIPTION
Results from running the tests with signify-ts

Task | 1 concurrent running | 2 concurrent running | 3 concurrent running | 4 concurrent running | 5 concurrent running
-- | -- | -- | -- | -- | --
Creating an agent for the first time | ~2 seconds | ~2.3 seconds | ~2.3 seconds | ~2.3 seconds | ~2.3 seconds
Connecting to agent | ~200 milliseconds | ~240 milliseconds | ~240 milliseconds | ~240 milliseconds | ~280 milliseconds
Creating and storing AIDs | ~100 milliseconds | ~100 milliseconds | ~100 milliseconds | ~100 milliseconds | ~100 milliseconds
Issuing Credential | ~3 seconds | ~3.5 seconds | ~3.5 seconds | ~3.5 seconds | ~4 seconds
Revoking Credential | ~700 milliseconds | ~800 milliseconds | ~800 milliseconds | ~900 milliseconds | 900 milliseconds
Verifying credential | ~300 milliseconds | ~400 milliseconds | ~400 milliseconds | ~400 milliseconds | ~500 milliseconds
Verifying revoked credential | ~400 milliseconds | ~500 milliseconds | ~500 milliseconds | ~600 milliseconds | ~600 milliseconds
OOBI resolution | ~50 milliseconds | ~150 milliseconds | ~150 milliseconds | ~150 milliseconds | ~150 milliseconds

Note:
Agent AIDS takes 3-4 seconds with _medium_ entropy and 6-7 seconds for _high_ entropy on the client side