### PR TITLE
Release idle agents 

### DIFF
--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -781,7 +781,7 @@ class Escrower(doing.Doer):
 
 class Releaser(doing.Doer):
     KERIAReleaserTimeOut = "KERIA_RELEASER_TIMEOUT"
-    TimeoutRel = os.getenv(KERIAReleaserTimeOut) or 1*60*60
+    TimeoutRel = int(os.getenv(KERIAReleaserTimeOut)) or 1*60*60
     def __init__(self, agency):
         """ Check open agents and close if idle for more than TimeoutRel seconds
 

--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -6,6 +6,7 @@ keria.app.agenting module
 """
 import json
 import os
+import datetime
 from dataclasses import asdict
 from urllib.parse import urlparse, urljoin
 
@@ -171,7 +172,7 @@ class Agency(doing.DoDoer):
         self.agents = dict()
 
         self.adb = adb if adb is not None else basing.AgencyBaser(name="TheAgency", base=base, reopen=True, temp=temp)
-        super(Agency, self).__init__(doers=[], always=True)
+        super(Agency, self).__init__(doers=[Releaser(self)], always=True)
 
     def create(self, caid):
         ks = keeping.Keeper(name=caid,
@@ -227,9 +228,25 @@ class Agency(doing.DoDoer):
 
         del self.agents[agent.caid]
 
+    def close(self, agent):
+        agent.hby.ks.close(clear=False)
+        agent.seeker.close(clear=False)
+        agent.exnseeker.close(clear=False)
+        agent.monitor.opr.close(clear=False)
+        agent.notifier.noter.close(clear=False)
+        agent.rep.mbx.close(clear=False)
+        agent.registrar.rgy.close()
+        agent.mgr.rb.close(clear=False)
+        agent.hby.close(clear=False)
+        self.remove(agent.doers)
+        self.remove([agent])
+        del self.agents[agent.caid]
+
     def get(self, caid):
         if caid in self.agents:
-            return self.agents[caid]
+            agent = self.agents[caid]
+            agent.last = helping.nowUTC()
+            return agent
 
         aaid = self.adb.agnt.get(keys=(caid,))
         if aaid is None:
@@ -286,6 +303,8 @@ class Agent(doing.DoDoer):
         self.agentHab = agentHab
         self.agency = agency
         self.caid = caid
+
+        self.last = helping.nowUTC()
 
         self.swain = delegating.Sealer(hby=hby, proxy=agentHab)
         self.counselor = Counselor(hby=hby, swain=self.swain, proxy=agentHab)
@@ -760,6 +779,32 @@ class Escrower(doing.Doer):
 
             yield self.tock
 
+class Releaser(doing.Doer):
+    TimeoutRel = 24*60*60
+    def __init__(self, agency):
+        """ Check open agents and close if idle for more than TimeoutRel seconds
+
+        Parameters:
+            agents (dict): dictionary of agents keyed by caid
+ 
+        """
+        self.tock = 60.0
+        self.agents = agency.agents
+        self.agency = agency
+
+        super(Releaser, self).__init__(tock=self.tock)
+
+    def recur(self, tyme=None):
+        while True:
+            idle = []
+            for caid in self.agents:
+                now = helping.nowUTC()
+                if (now - self.agents[caid].last) > datetime.timedelta(seconds=self.TimeoutRel):
+                    idle.append(caid)
+                    
+            for caid in idle:
+                self.agency.close(self.agents[caid])
+            yield self.tock
 
 def loadEnds(app):
     opColEnd = longrunning.OperationCollectionEnd()

--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -780,7 +780,8 @@ class Escrower(doing.Doer):
             yield self.tock
 
 class Releaser(doing.Doer):
-    TimeoutRel = 24*60*60
+    KERIAReleaserTimeOut = "KERIA_RELEASER_TIMEOUT"
+    TimeoutRel = os.getenv(KERIAReleaserTimeOut) or 1*60*60
     def __init__(self, agency):
         """ Check open agents and close if idle for more than TimeoutRel seconds
 


### PR DESCRIPTION
This PR generates a process that runs every 60 seconds and check if an agent was idle for more that 24 hours. In that case, the agent is shut down, releasing locked lmdb files and terminating its doers.